### PR TITLE
Simplify the process of overriding spark-defaults

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,12 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository before making a change. 
+Fork, then clone the repo:
+```
+git clone git@github.com:your-username/docker-spark.git
+```
+
+Make your changes, push to your fork and [submit a pull request](https://github.com/cjonesy/docker-spark/compare/).
+
 
 ## Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change. 
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a 
+   build.
+2. Update the README.md with details of changes to the interface, this includes new environment 
+   variables, exposed ports, useful file locations and container parameters.
+4. You may merge the Pull Request in once you have the sign-off from another developer, or if you 
+   do not have permission to do that, you may request the reviewer to merge it for you.

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN curl -L --retry 3 \
     ln -s /usr/spark-$SPARK_VERSION-bin-without-hadoop $SPARK_HOME && \
     rm -rf $SPARK_HOME/examples
 
+COPY spark-defaults.conf $SPARK_HOME/conf/spark-defaults.conf
 
 #-------------------------------------------------------------------------------
 # Entry

--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
 # docker-spark
-A barebones Docker image for Apache Spark 
+[![Docker Hub](https://img.shields.io/badge/docker-ready-blue.svg)](https://hub.docker.com/r/cjonesy/docker-spark/)
+[![Docker Build Status](https://img.shields.io/docker/build/cjonesy/docker-spark.svg)]()
+[![Docker Pulls](https://img.shields.io/docker/pulls/cjonesy/docker-spark.svg)]()
+[![Docker Stars](https://img.shields.io/docker/stars/cjonesy/docker-spark.svg)]()
+
+This repository contains **Dockerfile** of [Apache Spark](https://github.com/apache/spark) for [Docker](https://www.docker.com/)'s [automated build](https://hub.docker.com/r/cjonesy/docker-spark/) published to the public [Docker Hub Registry](https://registry.hub.docker.com/).
+
+## Installation
+
+Pull the image from the Docker repository.
+```
+docker pull cjonesy/docker-spark:latest
+```
+
+## Build
+```
+docker build --rm -t cjonesy/docker-spark:latest .
+```
+
+## Usage
+
+### For a Spark shell inside the container
+```
+docker run -it cjonesy/docker-spark:latest spark-shell
+```
+
+### For a PySpark shell inside the container
+```
+docker run -it cjonesy/docker-spark:latest pyspark
+```
+
+### For a Bash shell inside the container
+```
+docker run -it cjonesy/docker-spark:latest bash
+```
+
+## Configuration
+
+### spark-defaults.conf
+It is possible to override the following values in `spark-defaults.conf` from environment variables.
+
+| Property                      | Environment Variable          | Default Value            |
+| ----------------------------- | ----------------------------- | ------------------------ |
+| spark.driver.cores            | SPARK_DRIVER_CORES            | 1                        |
+| spark.driver.maxResultSize    | SPARK_DRIVER_MAXRESULTSIZE    | 1g                       |
+| spark.driver.memory           | SPARK_DRIVER_MEMORY           | 5g                       |
+| spark.exector.memory          | SPARK_EXECUTOR_MEMORY         | 5g                       |
+| spark.local.dir               | SPARK_LOCAL_DIR               | /tmp                     |
+| spark.logConf                 | SPARK_LOGCONF                 | true                     |
+| spark.master                  | SPARK_MASTER                  | local                    |
+| spark.driver.supervise        | SPARK_DRIVER_SUPERVISE        | false                    |
+| spark.driver.extraClassPath   | SPARK_DRIVER_EXTRACLASSPATH   | /jars/*                  |
+| spark.executor.extraClassPath | SPARK_EXECUTOR_EXTRACLASSPATH | /jars/*                  |
+| spark.python.worker.memory    | SPARK_PYTHON_WORKER_MEMORY    | 512m                     |
+| spark.ui.enabled              | SPARK_UI_ENABLED              | true                     |
+| spark.eventLog.enabled        | SPARK_EVENTLOG_ENABLED        | false                    |
+| spark.eventLog.dir            | SPARK_EVENTLOG_DIR            | file:///tmp/spark-events |
+
+
+Example:
+```
+docker run -e SPARK_UI_ENABLED=false -it cjones/docker-spark spark-shell
+```
+
+## How to contribute
+
+*Imposter syndrome disclaimer*: I want your help. No really, I do.
+
+There might be a little voice inside that tells you you're not ready; that you need to do one more tutorial, or learn another framework, or write a few more blog posts before you can help me with this project.
+
+I assure you, that's not the case.
+
+This project has some clear Contribution Guidelines and expectations that you can read here ([CONTRIBUTING](CONTRIBUTING.md)).
+
+The contribution guidelines outline the process that you'll need to follow to get a patch merged. By making expectations and process explicit, I hope it will make it easier for you to contribute.
+
+And you don't just have to write code. You can help out by writing documentation, tests, or even by giving feedback about this work. (And yes, that includes giving feedback about the contribution guidelines.)
+
+Thank you for contributing!

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,61 @@
 #!/usr/bin/env bash
 set -e
 
-if [[ -n $SPARK_DEFAULTS ]]; then
-IFS=';'; for default in $SPARK_DEFAULTS; do
-    echo "$default" >> $SPARK_HOME/conf/spark-defaults.conf
-done
-else
-cat > $SPARK_HOME/conf/spark-defaults.conf << EOF
-spark.driver.memory              5g
-spark.executor.memory            5g
-spark.driver.extraClassPath      /jars/*
-spark.executor.extraClassPath    /jars/*
-EOF
+# Overrides for spark-defaults.conf
+if [[ -n $SPARK_DRIVER_CORES ]]; then
+  sed -i "s/^spark.driver.cores.*$/spark.driver.cores $SPARK_DRIVER_CORES/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_DRIVER_MAXRESULTSIZE ]]; then
+  sed -i "s/^spark.driver.maxResultSize.*$/spark.driver.maxResultSize $SPARK_DRIVER_MAXRESULTSIZE/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_DRIVER_MEMORY ]]; then
+  sed -i "s/^spark.driver.memory.*$/spark.driver.memory $SPARK_DRIVER_MEMORY/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_EXECUTOR_MEMORY ]]; then
+  sed -i "s/^spark.executor.memory.*$/spark.executor.memory $SPARK_EXECUTOR_MEMORY/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_LOCAL_DIR ]]; then
+  sed -i "s/^spark.local.dir.*$/spark.local.dir $SPARK_LOCAL_DIR/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_LOGCONF ]]; then
+  sed -i "s/^spark.logConf.*$/spark.logConf $SPARK_LOGCONF/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_MASTER ]]; then
+  sed -i "s/^spark.master.*$/spark.master $SPARK_MASTER/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_DRIVER_SUPERVISE ]]; then
+  sed -i "s/^spark.driver.supervise.*$/spark.driver.supervise $SPARK_DRIVER_SUPERVISE/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_DRIVER_EXTRACLASSPATH ]]; then
+  sed -i "s/^spark.driver.extraClassPath.*$/spark.driver.extraClassPath $SPARK_DRIVER_EXTRACLASSPATH/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_EXECUTOR_EXTRACLASSPATH ]]; then
+  sed -i "s/^spark.executor.extraClassPath.*$/spark.executor.extraClassPath $SPARK_EXECUTOR_EXTRACLASSPATH/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_PYTHON_WORKER_MEMORY ]]; then
+  sed -i "s/^spark.python.worker.memory.*$/spark.python.worker.memory $SPARK_PYTHON_WORKER_MEMORY/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_UI_ENABLED ]]; then
+  sed -i "s/^spark.ui.enabled.*$/spark.ui.enabled $SPARK_UI_ENABLED/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_EVENTLOG_ENABLED ]]; then
+  sed -i "s/^spark.eventLog.enabled.*$/spark.eventLog.enabled $SPARK_EVENTLOG_ENABLED/" $SPARK_HOME/conf/spark-defaults.conf
+fi
+
+if [[ -n $SPARK_EVENTLOG_DIR ]]; then
+  sed -i "s/^spark.eventLog.dir.*$/spark.eventLog.dir $SPARK_EVENTLOG_DIR/" $SPARK_HOME/conf/spark-defaults.conf
 fi
 
 echo "Executing: $@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,4 +59,4 @@ if [[ -n $SPARK_EVENTLOG_DIR ]]; then
 fi
 
 echo "Executing: $@"
-exec $@
+exec "$@"

--- a/spark-defaults.conf
+++ b/spark-defaults.conf
@@ -1,0 +1,94 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default system properties included when running spark-submit.
+# This is useful for setting default environmental settings.
+
+###############################################################################
+# Application Properties
+
+# Number of cores to use for the driver process, only in cluster mode.
+spark.driver.cores 1
+
+# Limit of total size of serialized results of all partitions for each Spark
+# action (e.g. collect). Should be at least 1M, or 0 for unlimited. Jobs will 
+# be aborted if the total size is above this limit. Having a high limit may 
+# cause out-of-memory errors in driver (depends on spark.driver.memory and 
+# memory overhead of objects in JVM). Setting a proper limit can protect the 
+# driver from out-of-memory errors.
+spark.driver.maxResultSize 1g
+
+# Amount of memory to use for the driver process, i.e. where SparkContext is
+# initialized. (e.g. 1g, 2g). 
+spark.driver.memory 5g
+
+# Amount of memory to use per executor process (e.g. 2g, 8g).
+spark.executor.memory 5g
+
+# Directory to use for "scratch" space in Spark, including map output files
+# and RDDs that get stored on disk. This should be on a fast, local disk in
+# your system. It can also be a comma-separated list of multiple directories 
+# on different disks. 
+spark.local.dir /tmp
+
+# Logs the effective SparkConf as INFO when a SparkContext is started
+spark.logConf true
+
+# The cluster manager to connect to. See the list of allowed master URL's:
+# https://spark.apache.org/docs/latest/submitting-applications.html#master-urls
+spark.master local
+
+# If true, restarts the driver automatically if it fails with a non-zero exit
+# status. Only has effect in Spark standalone mode or Mesos cluster deploy mode.
+spark.driver.supervise false
+
+
+###############################################################################
+# Runtime Environment
+
+# Extra classpath entries to prepend to the classpath of the driver.
+spark.driver.extraClassPath /jars/*
+
+# Extra classpath entries to prepend to the classpath of executors. 
+spark.executor.extraClassPath /jars/*
+
+# Amount of memory to use per python worker process during aggregation, in the 
+# same format as JVM memory strings (e.g. 512m, 2g). If the memory used during 
+# aggregation goes above this amount, it will spill the data into disks.
+spark.python.worker.memory 512m
+
+
+###############################################################################
+# Shuffle Behavior
+
+
+###############################################################################
+# Spark UI
+
+# Whether to run the web UI for the Spark application.
+spark.ui.enabled true
+
+# Whether to log Spark events, useful for reconstructing the Web UI after the
+# application has finished.
+spark.eventLog.enabled false
+
+# Base directory in which Spark events are logged, if spark.eventLog.enabled is
+# true. Within this base directory, Spark creates a sub-directory for each
+# application, and logs the events specific to the application in this 
+# directory. Users may want to set this to a unified location like an HDFS
+# directory so history files can be read by the history server.
+spark.eventLog.dir file:///tmp/spark-events


### PR DESCRIPTION
- Environment variable overrides for spark-defaults.conf are more explicit
- Fixes problems with quoted arguments in entrypoint.sh
- Updated README.md and CONTRIBUTING.md